### PR TITLE
refactor: move yarn check-version to separate job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,22 @@ on:
       - docs/**
 
 jobs:
+  check-version:
+    name: Check Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install
+      - name: Check version consistency
+        run: yarn check-version
   build:
+    needs: check-version
     strategy:
       fail-fast: false
       matrix:
@@ -132,8 +147,6 @@ jobs:
         shell: bash
       - name: Install dependencies
         run: yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Setup node x86
         uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
@@ -207,7 +220,8 @@ jobs:
   #         if-no-files-found: error
   test-macOS-windows-binding:
     name: Test bindings on ${{ matrix.settings.target }} - node@${{ matrix.node }}
-    needs:
+    needs: 
+      - check-version
       - build
     strategy:
       fail-fast: false
@@ -231,8 +245,6 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -246,6 +258,7 @@ jobs:
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:
+      - check-version
       - build
     strategy:
       fail-fast: false
@@ -263,8 +276,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -278,6 +289,7 @@ jobs:
   test-linux-x64-musl-binding:
     name: Test bindings on x86_64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
+      - check-version
       - build
     strategy:
       fail-fast: false
@@ -297,8 +309,6 @@ jobs:
         run: |
           yarn config set supportedArchitectures.libc "musl"
           yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -312,6 +322,7 @@ jobs:
   test-linux-aarch64-gnu-binding:
     name: Test bindings on aarch64-unknown-linux-gnu - node@${{ matrix.node }}
     needs:
+      - check-version
       - build
     strategy:
       fail-fast: false
@@ -335,8 +346,6 @@ jobs:
           yarn config set supportedArchitectures.cpu "arm64"
           yarn config set supportedArchitectures.libc "glibc"
           yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -354,6 +363,7 @@ jobs:
   test-linux-aarch64-musl-binding:
     name: Test bindings on aarch64-unknown-linux-musl - node@${{ matrix.node }}
     needs:
+      - check-version
       - build
     runs-on: ubuntu-latest
     steps:
@@ -371,8 +381,6 @@ jobs:
           yarn config set supportedArchitectures.cpu "arm64"
           yarn config set supportedArchitectures.libc "musl"
           yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -389,6 +397,7 @@ jobs:
   test-linux-arm-gnueabihf-binding:
     name: Test bindings on armv7-unknown-linux-gnueabihf - node@${{ matrix.node }}
     needs:
+      - check-version
       - build
     strategy:
       fail-fast: false
@@ -411,8 +420,6 @@ jobs:
         run: |
           yarn config set supportedArchitectures.cpu "arm"
           yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
@@ -430,6 +437,7 @@ jobs:
   universal-macOS:
     name: Build universal macOS binary
     needs:
+      - check-version
       - build
     runs-on: macos-latest
     steps:
@@ -441,8 +449,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Download macOS x64 artifact
         uses: actions/download-artifact@v4
         with:
@@ -466,6 +472,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       # - build-freebsd
+      - check-version
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
       - test-linux-x64-musl-binding
@@ -482,8 +489,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install
-      - name: Check version consistency
-        run: yarn check-version
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
### Summary

Moved `yarn check-version` to a separate GitHub Actions job to avoid redundant checks in each platform build.

### What was done:
- Created a `check-version` job to handle version consistency.
- Removed the `yarn check-version` step from all other jobs.
- Added `needs: check-version` to relevant jobs.

This should speed up the workflow .

Let me know if anything needs adjustment!
